### PR TITLE
Fixed error preventing pip3 install from working.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup
 
 
-long_description = open("README.rst", "r").read().decode("utf-8")
+long_description = open("README.rst", "r").read()
 
 classifiers = [
             "Programming Language :: Python",


### PR DESCRIPTION
When attempting to install this package with pip3, I have the following issue:

    (venv)asdf-MBP:simple-rbac springtangent$ pip3 install simple-rbac
    Collecting simple-rbac
      Using cached simple-rbac-0.1.1.zip
        Complete output from command python setup.py egg_info:
        Traceback (most recent call last):
          File "<string>", line 20, in <module>
          File "/private/var/folders/0m/_05yt2x9537bsy66t2bq0wdc0000gn/T/pip-build-c4bipknu/simple-    rbac/setup.py", line 7, in <module>
            long_description = open("README.rst", "r").read().decode("utf-8")
        AttributeError: 'str' object has no attribute 'decode'
    
    ----------------------------------------
    Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/0m/_05yt2x9537bsy66t2bq0wdc0000gn/T/pip-build-c4bipknu/simple-rbac

removing the call to "decode" seems to fix the issue.