### PR TITLE
Preserve role evaluation order and add short circuiting

### DIFF
--- a/rbac/acl.py
+++ b/rbac/acl.py
@@ -15,6 +15,8 @@ class Registry(object):
         self._resources = {}
         self._allowed = {}
         self._denied = {}
+        self._denial_only_roles = set()  # to allow additional short circuiting, track roles that only ever deny access
+        self._children = {}
 
     def add_role(self, role, parents=[]):
         """Add a role or append parents roles to a special role.
@@ -24,6 +26,13 @@ class Registry(object):
         """
         self._roles.setdefault(role, set())
         self._roles[role].update(parents)
+        for p in parents:
+            self._children.setdefault(p, set())
+            self._children[p].add(role)
+
+        # all roles start as deny-only (unless one of its parents isn't deny-only)
+        if not parents or self._roles_are_deny_only(parents):
+            self._denial_only_roles.add(role)
 
     def add_resource(self, resource, parents=[]):
         """Add a resource or append parents resources to a special resource.
@@ -44,6 +53,10 @@ class Registry(object):
         assert not resource or resource in self._resources
         self._allowed[role, operation, resource] = assertion
 
+        # since we just allowed a permission, role and any children aren't denied-only
+        for r in itertools.chain([role], get_family(self._children, role)):
+            self._denial_only_roles.discard(r)
+
     def deny(self, role, operation, resource, assertion=None):
         """Add a denied rule.
 
@@ -54,7 +67,7 @@ class Registry(object):
         assert not resource or resource in self._resources
         self._denied[role, operation, resource] = assertion
 
-    def is_allowed(self, role, operation, resource):
+    def is_allowed(self, role, operation, resource, check_allowed=True):
         """Check the permission.
 
         If the access is denied, this method will return False; if the access
@@ -65,7 +78,7 @@ class Registry(object):
         assert not resource or resource in self._resources
 
         roles = set(get_family(self._roles, role))
-        operations = set([None, operation])
+        operations = {None, operation}
         resources = set(get_family(self._resources, resource))
 
         is_allowed = None
@@ -77,7 +90,7 @@ class Registry(object):
                 if assertion(self, role, operation, resource):
                     return False  # denied by rule immediately
 
-            if permission in self._allowed:
+            if check_allowed and permission in self._allowed:
                 assertion = self._allowed[permission] or default_assertion
                 if assertion(self, role, operation, resource):
                     is_allowed = True  # allowed by rule
@@ -86,14 +99,22 @@ class Registry(object):
 
     def is_any_allowed(self, roles, operation, resource):
         """Check the permission with many roles."""
-        is_allowed = None  # there is not matching rules
-        for role in roles:
-            is_current_allowed = self.is_allowed(role, operation, resource)
+        is_allowed = None  # no matching rules
+        for i, role in enumerate(roles):
+            # if access not yet allowed and all remaining roles could only deny access, short-circuit and return False
+            if not is_allowed and self._roles_are_deny_only(roles[i:]):
+                return False
+
+            check_allowed = not is_allowed  # if another role gave access, don't bother checking if this one is allowed
+            is_current_allowed = self.is_allowed(role, operation, resource, check_allowed=check_allowed)
             if is_current_allowed is False:
                 return False  # denied by rule
             elif is_current_allowed is True:
                 is_allowed = True
         return is_allowed
+
+    def _roles_are_deny_only(self, roles):
+        return all(r in self._denial_only_roles for r in roles)
 
 
 def get_family(all_parents, current):

--- a/rbac/context.py
+++ b/rbac/context.py
@@ -85,8 +85,10 @@ class IdentityContext(object):
                    for role_group in role_groups)
 
     def _docheck(self, operation, resource):
-        had_roles = frozenset(self.load_roles())
-        return self.acl.is_any_allowed(had_roles, operation, resource)
+        had_roles = self.load_roles()
+        role_list = list(had_roles)
+        assert len(role_list) == len(set(role_list))  # duplicate role check
+        return self.acl.is_any_allowed(role_list, operation, resource)
 
 
 class PermissionDenied(Exception):

--- a/rbac/proxy.py
+++ b/rbac/proxy.py
@@ -87,15 +87,15 @@ class RegistryProxy(object):
         resource = self.make_resource(resource)
         return self.acl.deny(role, operation, resource, assertion)
 
-    def is_allowed(self, role, operation, resource):
+    def is_allowed(self, role, operation, resource, **assertion_kwargs):
         role = self.make_role(role)
         resource = self.make_resource(resource)
-        return self.acl.is_allowed(role, operation, resource)
+        return self.acl.is_allowed(role, operation, resource, **assertion_kwargs)
 
-    def is_any_allowed(self, roles, operation, resource):
+    def is_any_allowed(self, roles, operation, resource, **assertion_kwargs):
         roles = [self.make_role(role) for role in roles]
         resource = self.make_resource(resource)
-        return self.acl.is_any_allowed(roles, operation, resource)
+        return self.acl.is_any_allowed(roles, operation, resource, **assertion_kwargs)
 
     def __getattr__(self, attr):
         return getattr(self.acl, attr)

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+#-*- coding:utf-8 -*-
+
+import unittest
+
+import rbac.acl
+import rbac.context
+
+
+class _FunctionProxy(object):
+        def __init__(self, fn, evaluated_roles, role_idx=0):
+            self.fn = fn
+            self.role_idx = role_idx
+            self.evaluated_roles = evaluated_roles
+
+        def __call__(self, *args, **kwargs):
+            role = args[self.role_idx]
+            self.evaluated_roles.append(role)
+            return self.fn.__call__(*args, **kwargs)
+
+
+class OrderingTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.acl = rbac.acl.Registry()
+        self.context = rbac.context.IdentityContext(self.acl)
+        self.evaluated_roles = []
+
+    def test_role_evaluation_order_preserved(self):
+        # decorate acl.is_allowed so we can track role evaluation order
+        setattr(self.acl, 'is_allowed', _FunctionProxy(self.acl.is_allowed, self.evaluated_roles))
+
+        # add roles as a list in the expected order (1 through 10)
+        self.acl.add_resource('my_resource')
+        roles = [str(i) for i in xrange(10)]
+        for i, role in enumerate(roles):
+            self.acl.add_role(role)
+        self.context.set_roles_loader(lambda: roles)
+        self.acl.allow(roles[9], 'view', 'my_resource')  # allow only the final role to avoid short-circuiting
+        self.context.has_permission('view', 'my_resource')
+
+        # check that the roles were evaluated in order
+        self.assertEqual(roles, self.evaluated_roles)
+
+    def test_short_circuit_skip_deny(self):
+        """ If no remaining role could grant access, don't bother checking """
+        # track which roles are evaluated
+        setattr(self.acl, 'is_allowed', _FunctionProxy(self.acl.is_allowed, self.evaluated_roles))
+
+        self.acl.add_resource('the dinosaurs')
+        roles = ['tourist', 'scientist', 'intern']
+        for role in roles:
+            self.acl.add_role(role)
+        self.context.set_roles_loader(lambda: roles)
+        # explicitly deny one role, and simply don't allow any permissions to the others
+        self.acl.deny('intern', 'feed', 'the dinosaurs')
+        self.context.has_permission('feed', 'the dinosaurs')
+
+        # no roles checked, since all are deny-only
+        self.assertEqual([], self.evaluated_roles)
+
+        self.acl.allow('scientist', 'study', 'the dinosaurs')
+        self.context.has_permission('feed', 'the dinosaurs')
+
+        # since scientist is no longer deny-only, only the intern check will be skipped
+        self.assertEqual(['tourist', 'scientist'], self.evaluated_roles)
+
+    def test_short_circuit_skip_allow(self):
+        """ once one role is allowed, shouldn't check whether other roles are allowed """
+        # track which roles have their assertion function evaluated
+        assertion = _FunctionProxy(lambda *args, **kwargs: args[1] == '3', self.evaluated_roles, role_idx=1)
+
+        self.acl.add_resource('my_resource')
+        roles = [str(i) for i in xrange(10)]
+        for i, role in enumerate(roles):
+            self.acl.add_role(role)
+            self.acl.allow(role, 'view', 'my_resource', assertion=assertion)
+        self.context.set_roles_loader(lambda: roles)
+        self.context.has_permission('view', 'my_resource')
+
+        # since role '3' was allowed, 'allowed' isn't checked on any subsequent role
+        self.assertEqual(roles[0:4], self.evaluated_roles)

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -8,15 +8,15 @@ import rbac.context
 
 
 class _FunctionProxy(object):
-        def __init__(self, fn, evaluated_roles, role_idx=0):
-            self.fn = fn
-            self.role_idx = role_idx
-            self.evaluated_roles = evaluated_roles
+    def __init__(self, fn, evaluated_roles, role_idx=0):
+        self.fn = fn
+        self.role_idx = role_idx
+        self.evaluated_roles = evaluated_roles
 
-        def __call__(self, *args, **kwargs):
-            role = args[self.role_idx]
-            self.evaluated_roles.append(role)
-            return self.fn.__call__(*args, **kwargs)
+    def __call__(self, *args, **kwargs):
+        role = args[self.role_idx]
+        self.evaluated_roles.append(role)
+        return self.fn.__call__(*args, **kwargs)
 
 
 class OrderingTestCase(unittest.TestCase):

--- a/tests/testcontext.py
+++ b/tests/testcontext.py
@@ -57,15 +57,15 @@ class ContextTestCase(unittest.TestCase):
         check_view = self.context.check_permission("view", "article")
         check_edit = self.context.check_permission("edit", "article")
 
-        for i in self._to_be_staff():
+        for _ in self._to_be_staff():
             self.assertTrue(bool(check_view))
             self.assertFalse(bool(check_edit))
 
-        for i in self._to_be_editor():
+        for _ in self._to_be_editor():
             self.assertTrue(bool(check_view))
             self.assertTrue(bool(check_edit))
 
-        for i in self._to_be_badguy():
+        for _ in self._to_be_badguy():
             self.assertFalse(bool(check_view))
             self.assertFalse(bool(check_edit))
 
@@ -74,15 +74,15 @@ class ContextTestCase(unittest.TestCase):
     # -------------------
 
     def _assert_call(self, view_article, edit_article):
-        for i in self._to_be_staff():
+        for _ in self._to_be_staff():
             self.assertTrue(view_article())
             self.assertRaises(self.denied_error, edit_article)
 
-        for i in self._to_be_editor():
+        for _ in self._to_be_editor():
             self.assertTrue(view_article())
             self.assertTrue(edit_article())
 
-        for i in self._to_be_badguy():
+        for _ in self._to_be_badguy():
             self.assertRaises(self.denied_error, view_article)
             self.assertRaises(self.denied_error, edit_article)
 

--- a/tests/testproxy.py
+++ b/tests/testproxy.py
@@ -155,10 +155,10 @@ class ProxyTestCase(unittest.TestCase):
         one_denied_with_allowed = ["staff", "editor", "manager"]
 
         test_result = lambda roles: self.proxy.is_any_allowed(
-                (Role.query(r) for r in roles), "edit", Post)
+            (Role.query(r) for r in roles), "edit", Post)
 
         for roles in (no_allowed, no_allowed_one):
-            self.assertIsNone(test_result(roles))
+            self.assertFalse(test_result(roles))
 
         for roles in (one_allowed, one_allowed_only):
             self.assertTrue(test_result(roles))


### PR DESCRIPTION
This branch has a few miscellaneous changes that I needed for a project I was working on, in which the optional assertion function was potentially expensive:
- Preserve evaluation order from the role loader function. If some roles are cheaper to evaluate than others (e.g. because they have a less expensive assertion function), evaluate them first.
- Add short-circuiting during role evaluation. Once a permission is definitely allowed or denied, don't bother evaluating additional roles.
- Allow arbitrary kwargs in the optional assertion, which allows for more flexible assertion functions.